### PR TITLE
Add username/password login page + integrate PIN

### DIFF
--- a/app.json
+++ b/app.json
@@ -18,7 +18,8 @@
         {
           "faceIDPermission": "Allow $(PRODUCT_NAME) to use Face ID."
         }
-      ]
+      ],
+      "expo-secure-store"
     ],
     "splash": {
       "image": "./assets/splash.png",

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "expo": "^52.0.6",
         "expo-camera": "~16.0.5",
         "expo-local-authentication": "~15.0.1",
+        "expo-secure-store": "~14.0.0",
         "expo-status-bar": "~2.0.0",
         "g": "^2.0.1",
         "react": "18.3.1",
@@ -7590,6 +7591,15 @@
       "license": "MIT",
       "dependencies": {
         "invariant": "^2.2.4"
+      }
+    },
+    "node_modules/expo-secure-store": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/expo-secure-store/-/expo-secure-store-14.0.0.tgz",
+      "integrity": "sha512-VyhtRFXP+7hQmHhKlHIOWid1Q/IRpM7Uif32tZHLZHvQ6FNz2cUkr26XWGvCa7btYbrR6OL++FBFZYjbIcRZTw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*"
       }
     },
     "node_modules/expo-status-bar": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
     "react-native-safe-area-context": "4.12.0",
     "react-native-screens": "~4.0.0",
     "react-native-vector-icons": "^10.2.0",
-    "react-native-web": "~0.19.10"
+    "react-native-web": "~0.19.10",
+    "expo-secure-store": "~14.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.26.0",

--- a/src/routes/DrawerNav/index.js
+++ b/src/routes/DrawerNav/index.js
@@ -5,6 +5,7 @@ import {
   DrawerItemList,
   DrawerItem,
 } from '@react-navigation/drawer';
+import * as SecureStore from 'expo-secure-store';
 import { View } from 'react-native';
 import SettingsScreen from '../../screens/Settings';
 import AboutScreen from '../../screens/About';
@@ -14,16 +15,22 @@ const Drawer = createDrawerNavigator();
 
 const CustomDrawerContent = (props) => {
   const { navigation } = props;
+
+  const handleLogOut = async () => {
+    try {
+      await SecureStore.deleteItemAsync('pin');
+    } finally {
+      navigation.reset({ index: 0, routes: [{ name: 'FirstLogin' }] });
+    }
+  };
+
   return (
     <DrawerContentScrollView {...props} contentContainerStyle={{ flex: 1 }}>
       <View style={{ flex: 1 }}>
         <DrawerItemList {...props} />
       </View>
       <View style={{ borderTopWidth: 1, borderColor: '#ccc' }}>
-        <DrawerItem
-          label="Log out"
-          onPress={() => navigation.popToTop()}
-        />
+        <DrawerItem label="Log out" onPress={handleLogOut} />
       </View>
     </DrawerContentScrollView>
   );

--- a/src/routes/StackNav/index.js
+++ b/src/routes/StackNav/index.js
@@ -19,8 +19,7 @@ function usePIN() {
   useEffect(() => {
     async function getPIN() {
       try {
-        const key = 'pin';
-        const pin = await SecureStore.getItemAsync(key);
+        const pin = await SecureStore.getItemAsync('pin');
         setPin(pin);
       } finally {
         setLoading(false);
@@ -41,12 +40,12 @@ function StackNav() {
   } else {
     return (
       <Stack.Navigator initialRouteName={pin ? 'Login' : 'FirstLogin'}>
-        <Stack.Screen name="FirstLogin" component={FirstLogin} />
         <Stack.Screen
           name="Login"
           component={LoginScreen}
-          initialParams={{ pin }}
+          initialParams={{ correctPin: pin }}
         />
+        <Stack.Screen name="FirstLogin" component={FirstLogin} />
         <Stack.Screen name="DrawerNav" component={DrawerNav} options={header} />
       </Stack.Navigator>
     );

--- a/src/routes/StackNav/index.js
+++ b/src/routes/StackNav/index.js
@@ -1,6 +1,7 @@
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import LoginScreen from '../../screens/Login';
 import DrawerNav from '../DrawerNav';
+import FirstLogin from '../../screens/FirstLogin';
 
 const Stack = createNativeStackNavigator();
 
@@ -11,6 +12,7 @@ const header = {
 function StackNav() {
   return (
     <Stack.Navigator>
+      <Stack.Screen name="FirstLogin" component={FirstLogin} />
       <Stack.Screen name="Login" component={LoginScreen} />
       <Stack.Screen name="DrawerNav" component={DrawerNav} options={header} />
     </Stack.Navigator>

--- a/src/screens/FirstLogin/index.js
+++ b/src/screens/FirstLogin/index.js
@@ -1,0 +1,82 @@
+import { useState } from 'react';
+import { Text, TextInput, Button, HelperText } from 'react-native-paper';
+import { View, StyleSheet } from 'react-native';
+
+function FirstLogin({ navigation }) {
+  const [login, setLogin] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState(false);
+
+  // TODO: proper authentication
+  const authenticated = (login, password) => {
+    return login === 'admin' && password === 'admin';
+  };
+
+  const handleSubmit = () => {
+    if (!login || !password) return;
+
+    if (authenticated(login, password)) {
+      navigation.navigate('Login');
+    } else {
+      setError(true);
+      setPassword('');
+    }
+  };
+
+  const handleTextChange = (setter, text) => {
+    setter(text.trim());
+    setError(false);
+  };
+
+  return (
+    <View style={styles.container}>
+      <Text variant="headlineSmall" style={styles.title}>
+        Logowanie
+      </Text>
+      <TextInput
+        label="Nazwa użytkownika"
+        mode="outlined"
+        onChangeText={(text) => handleTextChange(setLogin, text)}
+        value={login}
+        error={error}
+      />
+      <TextInput
+        label="Hasło"
+        mode="outlined"
+        secureTextEntry
+        onChangeText={(text) => handleTextChange(setPassword, text)}
+        value={password}
+        error={error}
+      />
+      <HelperText type="error" style={styles.helper} visible={error}>
+        Błędne dane logowania. Spróbuj ponownie.
+      </HelperText>
+      <Button mode="contained" style={styles.button} onPress={handleSubmit}>
+        Zaloguj się
+      </Button>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    padding: 16,
+    gap: 10,
+    padding: 16,
+    flex: 1,
+    backgroundColor: '#fff',
+  },
+  title: {
+    textAlign: 'center',
+    padding: 30,
+  },
+  helper: {
+    paddingLeft: 4,
+  },
+  button: {
+    borderRadius: 6,
+    padding: 5,
+  },
+});
+
+export default FirstLogin;

--- a/src/screens/FirstLogin/index.js
+++ b/src/screens/FirstLogin/index.js
@@ -16,7 +16,10 @@ function FirstLogin({ navigation }) {
     if (!login || !password) return;
 
     if (authenticated(login, password)) {
-      navigation.navigate('Login');
+      navigation.reset({
+        index: 0,
+        routes: [{ name: 'Login', params: { correctPin: null } }],
+      });
     } else {
       setError(true);
       setPassword('');

--- a/src/screens/FirstLogin/index.js
+++ b/src/screens/FirstLogin/index.js
@@ -34,17 +34,17 @@ function FirstLogin({ navigation }) {
   return (
     <View style={styles.container}>
       <Text variant="headlineSmall" style={styles.title}>
-        Logowanie
+        Login
       </Text>
       <TextInput
-        label="Nazwa użytkownika"
+        label="Username"
         mode="outlined"
         onChangeText={(text) => handleTextChange(setLogin, text)}
         value={login}
         error={error}
       />
       <TextInput
-        label="Hasło"
+        label="Password"
         mode="outlined"
         secureTextEntry
         onChangeText={(text) => handleTextChange(setPassword, text)}
@@ -52,10 +52,10 @@ function FirstLogin({ navigation }) {
         error={error}
       />
       <HelperText type="error" style={styles.helper} visible={error}>
-        Błędne dane logowania. Spróbuj ponownie.
+        Invalid username or password. Please try again.
       </HelperText>
       <Button mode="contained" style={styles.button} onPress={handleSubmit}>
-        Zaloguj się
+        Sign in
       </Button>
     </View>
   );

--- a/src/screens/Login/index.js
+++ b/src/screens/Login/index.js
@@ -1,10 +1,18 @@
 import React, { useState } from 'react';
 import { View, StyleSheet } from 'react-native';
-import { Text, TextInput, Button, IconButton, Snackbar  } from 'react-native-paper';
+import * as SecureStore from 'expo-secure-store';
+import {
+  Text,
+  TextInput,
+  Button,
+  IconButton,
+  Snackbar,
+} from 'react-native-paper';
 
-const LoginScreen = ({ navigation }) => {
+const LoginScreen = ({ navigation, route }) => {
   const [pin, setPin] = useState('');
   const [showSnackbar, setShowSnackbar] = useState(false);
+  const correctPin = route.params.correctPin;
 
   const handleNumberPress = (number) => {
     if (pin.length < 4) {
@@ -16,22 +24,30 @@ const LoginScreen = ({ navigation }) => {
     setPin((prevPin) => prevPin.slice(0, -1));
   };
 
-  const handleLogin = () => {
-    if (pin.length === 4 && pin === '1111') {
-      navigation.navigate('DrawerNav');
-    }else{
-      setShowSnackbar(true);
+  const handleLogin = async () => {
+    if (correctPin) {
+      if (pin.length === 4 && pin === correctPin) {
+        navigation.reset({ index: 0, routes: [{ name: 'DrawerNav' }] });
+      } else {
+        setShowSnackbar(true);
+      }
+    } else {
+      try {
+        await SecureStore.setItemAsync('pin', pin);
+      } finally {
+        navigation.reset({ index: 0, routes: [{ name: 'DrawerNav' }] });
+      }
     }
   };
 
   return (
     <View style={styles.container}>
-      <Snackbar
-        visible={showSnackbar}
-        onDismiss={() => setShowSnackbar(false)}>
+      <Snackbar visible={showSnackbar} onDismiss={() => setShowSnackbar(false)}>
         Nieprawidłowy PIN
       </Snackbar>
-      <Text style={styles.header}>Wprowadź PIN</Text>
+      <Text style={styles.header}>
+        {correctPin ? 'Wprowadź PIN' : 'Ustaw nowy PIN'}
+      </Text>
 
       <TextInput
         label="PIN"

--- a/src/screens/Login/index.js
+++ b/src/screens/Login/index.js
@@ -43,10 +43,10 @@ const LoginScreen = ({ navigation, route }) => {
   return (
     <View style={styles.container}>
       <Snackbar visible={showSnackbar} onDismiss={() => setShowSnackbar(false)}>
-        Nieprawidłowy PIN
+        Invalid PIN.
       </Snackbar>
       <Text style={styles.header}>
-        {correctPin ? 'Wprowadź PIN' : 'Ustaw nowy PIN'}
+        {correctPin ? 'Enter PIN' : 'Create new PIN'}
       </Text>
 
       <TextInput


### PR DESCRIPTION
### Logowanie za pomocą loginu i hasła

- Przy pierwszym wejściu do aplikacji należy zalogować się loginem i hasłem (na razie hard-coded: `admin`, `admin`).
- Na kolejnym ekranie trzeba ustawić nowy PIN.
- Wyjście z aplikacji na tym etapie spowoduje, że kolejnym razem do logowanie potrzebny będzie tylko PIN.
- Wylogowanie spowoduje cofnięcie do ekranu z loginem i hasłem, co jednocześnie wymusi ponowne ustawienie PINu.

W większości aplikacji bankowych tak by to działało (chyba).

PIN póki co jest przechowywany jedynie w [SecureStore](https://docs.expo.dev/versions/latest/sdk/securestore/).