### PR TITLE
Ostatnie transakcje używające nowej struktury pliku json-server

### DIFF
--- a/db.json
+++ b/db.json
@@ -41,92 +41,92 @@
     {
       "id": 1,
       "title": "Money sent to user",
-      "timestamp": 1700000000,
+      "timestamp": 1725800391,
       "amount": 200.5,
       "senderAccountNumber": "1234567890",
       "receiverAccountNumber": "3456789012",
-      "icon": "account-outline"
+      "icon": "personalTransfer"
     },
     {
       "id": 2,
       "title": "Money received from admin",
-      "timestamp": 1700003600,
+      "timestamp": 1728279413,
       "amount": 200.35,
-      "senderAccountNumber": "1234567890",
-      "receiverAccountNumber": "3456789012",
-      "icon": "account-outline"
+      "senderAccountNumber": "3456789012",
+      "receiverAccountNumber": "1234567890",
+      "icon": "personalTransfer"
     },
     {
       "id": 3,
       "title": "Gift for family",
-      "timestamp": 1700007200,
+      "timestamp": 1704800856,
       "amount": 150.0,
       "senderAccountNumber": "1234567890",
       "receiverAccountNumber": "8765432109",
-      "icon": "cart"
+      "icon": "shopping"
     },
     {
       "id": 4,
       "title": "Salary received",
-      "timestamp": 1700010800,
+      "timestamp": 1724653396,
       "amount": 2500.0,
-      "senderAccountNumber": "2345678901",
-      "receiverAccountNumber": "9876543210",
-      "icon": "briefcase"
+      "senderAccountNumber": "9876543210",
+      "receiverAccountNumber": "2345678901",
+      "icon": "salary"
     },
     {
       "id": 5,
       "title": "Electricity bill",
-      "timestamp": 1700014400,
+      "timestamp": 1734265532,
       "amount": 100.22,
       "senderAccountNumber": "1234567890",
       "receiverAccountNumber": "8765432109",
-      "icon": "lightbulb"
+      "icon": "bills"
     },
     {
       "id": 6,
       "title": "Rent payment",
-      "timestamp": 1700020000,
+      "timestamp": 1720408441,
       "amount": 1500.0,
       "senderAccountNumber": "2345678901",
       "receiverAccountNumber": "9876543210",
-      "icon": "bank"
+      "icon": "payment"
     },
     {
       "id": 7,
       "title": "Bonus received",
-      "timestamp": 1700023600,
+      "timestamp": 1729516011,
       "amount": 1000.0,
       "senderAccountNumber": "9876543210",
       "receiverAccountNumber": "2345678901",
-      "icon": "credit-card"
+      "icon": "salary"
     },
     {
       "id": 8,
       "title": "Shopping expenses",
-      "timestamp": 1700027200,
+      "timestamp": 1727716097,
       "amount": 250.75,
       "senderAccountNumber": "8765432109",
       "receiverAccountNumber": "1234567890",
-      "icon": "cart"
+      "icon": "shopping"
     },
     {
       "id": 9,
       "title": "Received refund",
-      "timestamp": 1700030800,
+      "timestamp": 1730438888,
       "amount": 200.0,
       "senderAccountNumber": "8765432109",
       "receiverAccountNumber": "9876543210",
-      "icon": "help-circle"
+      "icon": "service"
     },
     {
       "id": 10,
       "title": "Investment",
-      "timestamp": 1700034400,
+      "timestamp": 1730863974,
       "amount": 500.0,
       "senderAccountNumber": "2345678901",
       "receiverAccountNumber": "8765432109",
-      "icon": "tools"
+      "icon": "salary"
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "main": "expo/AppEntry.js",
   "scripts": {
     "start": "expo start",
+    "api": "npx json-server db.json",
     "android": "expo start --android",
     "ios": "expo start --ios",
     "web": "expo start --web",

--- a/src/api/accounts.js
+++ b/src/api/accounts.js
@@ -1,0 +1,11 @@
+import axiosInstance from './axiosInstance';
+
+export const getAccounts = (userId) =>
+  axiosInstance
+    .get(`accounts?userId=${userId}`)
+    .then(function ({ data }) {
+      return data;
+    })
+    .catch(function (error) {
+      console.log(error);
+    });

--- a/src/api/history.js
+++ b/src/api/history.js
@@ -1,11 +1,21 @@
-import axiosInstance from './axiosInstance';
+import { getTransactions } from './transactions';
 
-export const getHistory = () =>
-  axiosInstance
-    .get('transactions?_sort=-id&_page=1&_per_page=3')
-    .then(function ({ data }) {
-      return data?.data;
-    })
-    .catch(function (error) {
-      console.log(error);
-    });
+export const getHistory = async (accountNumber, limit) => {
+  const transactions = await Promise.all([
+    getTransactions(accountNumber, 'sender'),
+    getTransactions(accountNumber, 'receiver'),
+  ]);
+
+  const removeDuplicates = (acc, obj) => {
+    if (!acc.find((e) => e.id === obj.id)) {
+      acc.push(obj);
+    }
+    return acc;
+  };
+
+  return transactions
+    .flat()
+    .toSorted((a, b) => Number(a.id) - Number(b.id))
+    .reduce(removeDuplicates, [])
+    .slice(0, limit);
+};

--- a/src/api/transactions.js
+++ b/src/api/transactions.js
@@ -3,7 +3,7 @@ import axiosInstance from './axiosInstance';
 export const getTransactions = (accountNumber, role = 'sender') => {
   if (role !== 'sender' && role !== 'receiver') role = 'sender';
   return axiosInstance
-    .get(`transactions?${role}AccountNumber=${accountNumber}`)
+    .get(`transactions?${role}AccountNumber=${accountNumber}&_sort=-timestamp`)
     .then(function ({ data }) {
       return data;
     })

--- a/src/api/transactions.js
+++ b/src/api/transactions.js
@@ -1,0 +1,13 @@
+import axiosInstance from './axiosInstance';
+
+export const getTransactions = (accountNumber, role = 'sender') => {
+  if (role !== 'sender' && role !== 'receiver') role = 'sender';
+  return axiosInstance
+    .get(`transactions?${role}AccountNumber=${accountNumber}`)
+    .then(function ({ data }) {
+      return data;
+    })
+    .catch(function (error) {
+      console.log(error);
+    });
+};

--- a/src/screens/FirstLogin/index.js
+++ b/src/screens/FirstLogin/index.js
@@ -7,36 +7,37 @@ import * as SecureStore from 'expo-secure-store';
 function FirstLogin({ navigation }) {
   const [login, setLogin] = useState('');
   const [password, setPassword] = useState('');
-  const [error, setError] = useState(false);
+  const [error, setError] = useState('');
 
   // TODO: proper authentication
-  const authenticated = (login, password) => {
-    return onLogin({ login, password }).then(async (data) => {
-      if (data?.length > 0) {
-        await SecureStore.setItemAsync('idUser', JSON.stringify(data[0]?.id));
+  const authenticate = (login, password) => {
+    return onLogin({ login, password })
+      .then(async (data) => {
+        if (data?.length > 0) {
+          await SecureStore.setItemAsync('idUser', JSON.stringify(data[0]?.id));
 
-        navigation.reset({
-          index: 0,
-          routes: [{ name: 'Login', params: { correctPin: null } }],
-        });
-      } else {
-        setError(true);
-        setPassword('');
-      }
-
-      return true;
-    });
+          navigation.reset({
+            index: 0,
+            routes: [{ name: 'Login', params: { correctPin: null } }],
+          });
+        } else {
+          setError('Invalid username or password. Please try again.');
+          setPassword('');
+        }
+      })
+      .catch(() => {
+        setError('Internal server error.');
+      });
   };
 
   const handleSubmit = async () => {
     if (!login || !password) return;
-
-    await authenticated(login, password);
+    await authenticate(login, password);
   };
 
   const handleTextChange = (setter, text) => {
     setter(text.trim());
-    setError(false);
+    setError(null);
   };
 
   return (
@@ -60,7 +61,7 @@ function FirstLogin({ navigation }) {
         error={error}
       />
       <HelperText type="error" style={styles.helper} visible={error}>
-        Invalid username or password. Please try again.
+        {error}
       </HelperText>
       <Button mode="contained" style={styles.button} onPress={handleSubmit}>
         Sign in

--- a/src/screens/Home/index.js
+++ b/src/screens/Home/index.js
@@ -4,25 +4,38 @@ import { Ionicons } from '@expo/vector-icons';
 import { Text, useTheme, Button } from 'react-native-paper';
 import TransactionsListComponent from './transactionsListComponent';
 import { useIsFocused } from '@react-navigation/native';
-import { getHistory } from '../../api/history';
 import { useUserContext } from '../../contexts/UserContext';
+import { getAccounts } from '../../api/accounts';
 import * as SecureStore from 'expo-secure-store';
+import { getHistory } from '../../api/history';
+
+const TRANSACTIONS_IN_HISTORY = 3;
 
 function HomeScreen({ navigation }) {
   const { userInfo, setUserInfo } = useUserContext();
   const isFocused = useIsFocused();
   const theme = useTheme();
   const [transactionList, setTransactionList] = useState([]);
+  const [accountList, setAccountList] = useState([]);
 
   useEffect(() => {
-    getHistory().then((data) => {
-      console.log(data);
-    });
+    async function getHomeScreenData() {
+      const user = {
+        ...userInfo,
+        id: SecureStore.getItem('idUser'),
+      };
+      const accounts = await getAccounts(user.id);
+      const transactions = await getHistory(
+        accounts[0].accountNumber,
+        TRANSACTIONS_IN_HISTORY,
+      );
 
-    setUserInfo({
-      ...userInfo,
-      id: SecureStore.getItem('idUser'),
-    });
+      setUserInfo(user);
+      setAccountList(accounts);
+      setTransactionList(transactions);
+    }
+
+    getHomeScreenData();
   }, [isFocused]);
 
   useLayoutEffect(() => {

--- a/src/screens/Home/index.js
+++ b/src/screens/Home/index.js
@@ -22,7 +22,7 @@ function HomeScreen({ navigation }) {
     async function getHomeScreenData() {
       const user = {
         ...userInfo,
-        id: SecureStore.getItem('idUser'),
+        id: SecureStore.getItem('idUser').replace(/"/g, ''),
       };
       const accounts = await getAccounts(user.id);
       const transactions = await getHistory(

--- a/src/screens/Home/transactionsListComponent.js
+++ b/src/screens/Home/transactionsListComponent.js
@@ -3,10 +3,17 @@ import { View, StyleSheet } from 'react-native';
 import { Icon, Text, useTheme } from 'react-native-paper';
 import dayjs from 'dayjs';
 
+function limitText(text, maxLength) {
+  if (text.length > maxLength) {
+    return text.slice(0, maxLength - 3) + '...';
+  }
+  return text;
+}
+
 const TransactionsListComponent = ({ transaction }) => {
   const theme = useTheme();
 
-  const { title, date, amount, direction, type } = transaction;
+  const { title, timestamp, amount, direction, icon } = transaction;
 
   const iconMap = {
     shopping: 'cart',
@@ -36,14 +43,16 @@ const TransactionsListComponent = ({ transaction }) => {
         }}
       >
         <Icon
-          source={iconMap[type] || iconMap.other}
+          source={iconMap[icon] || iconMap.other}
           color={theme.colors.primary}
           size={48}
         />
       </View>
       <View style={{ flexDirection: 'column', marginLeft: 15, gap: 5 }}>
-        <Text style={{ fontSize: 16, fontWeight: '900' }}>{title}</Text>
-        <Text>{dayjs(date).format('DD-MM-YYYY hh:mm')}</Text>
+        <Text style={{ fontSize: 16, fontWeight: '900' }}>
+          {limitText(title, 20)}
+        </Text>
+        <Text>{dayjs(timestamp * 1000).format('DD-MM-YYYY hh:mm')}</Text>
       </View>
       <View style={{ flex: 1, justifyContent: 'center' }}>
         <Text style={{ textAlign: 'right', fontSize: 20, fontWeight: '900' }}>


### PR DESCRIPTION
+ Ostatnie transakcje wyświetlają się tak jak wcześniej, tzn. z odpowiednią ikonką i datą w kolejności od najnowszych transakcji - tylko że z wykorzystaniem danych w nowym pliku `db.json`.
+ Zbyt długi tytuł transakcji nie rozwala już całego layoutu ekranu.
+ Żeby pobrać transakcje trzeba było też fetchować rachunki użytkownika do których te transakcje należą; na ten moment są one w liście w state'cie i nic z nimi nie jest robione - dobrze by było dodać coś w stylu zmiany rachunku i wtedy aktualizowane byłyby też te ostatnie transakcje.
